### PR TITLE
fix: bump version 4.4.1

### DIFF
--- a/version.py
+++ b/version.py
@@ -1,7 +1,7 @@
 short_name = "Rex"
 name = "ReX Engine"
-major = 0
-minor = 1
+major = 1
+minor = 0
 patch = 0
 status = "beta"
 status_version = 0

--- a/version.py
+++ b/version.py
@@ -1,9 +1,9 @@
 short_name = "Rex"
 name = "ReX Engine"
-major = 4
-minor = 4
+major = 0
+minor = 1
 patch = 0
-status = "alpha"
+status = "beta"
 status_version = 0
 module_config = ""
 website = "https://redotengine.org"

--- a/version.py
+++ b/version.py
@@ -1,8 +1,8 @@
 short_name = "Rex"
 name = "ReX Engine"
-major = 1
-minor = 0
-patch = 0
+major = 4
+minor = 4
+patch = 1
 status = "beta"
 status_version = 0
 module_config = ""


### PR DESCRIPTION
This was pointless..   but we learned that there are tons of bogus hard coded version checks and the version must be greater than 4.x 