### PR TITLE
Fix: Cannot create script even when a valid path is set 

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -273,7 +273,7 @@ bool ScriptCreateDialog::_validate_parent(const String &p_string) {
 
 String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must_exist, bool p_try_match) {
 	String p = p_path.strip_edges();
-
+	is_path_valid = false;
 	if (p.is_empty()) {
 		return TTR("Path is empty.");
 	}
@@ -333,7 +333,7 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	if (language->get_extensions()[selected_script] != extension && p_try_match && _extension_update_selected_language(p.get_extension()) != OK) {
 		return TTR("Extension doesn't match chosen language.");
 	}
-
+	is_path_valid = true;
 	// Let ScriptLanguage do custom validation.
 	return language->validate_path(p);
 }


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.redotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixed an issue in ''/editor/script_create/dialog.cpp' where path validation was checked but not set due to conflicting prior changes.
'validate_path()' now properly sets 'is_path_valid' to 'false' at the beginning of the check, and then updates the value to 'true' of all checks pass.